### PR TITLE
Buffer Support (#2)

### DIFF
--- a/.duspec
+++ b/.duspec
@@ -16,7 +16,8 @@
   "dependencies":[
     "deltics.inc:1.3.0",
     "deltics.exceptions:1.1.0",
-    "deltics.stringtypes:1.1.0"
+    "deltics.memory:1.0.0",
+    "deltics.stringtypes:1.1.1"
   ],
   "source":{
       "files":[

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 mode: ContinuousDeployment
 increment: None
-next-version: 1.0.0
+next-version: 1.1.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/tests/.duget
+++ b/tests/.duget
@@ -1,6 +1,6 @@
 {
   "references":[
     "&..\\.duspec",
-    "deltics.smoketest:2.8.2"
+    "deltics.smoketest:2.9.0"
   ]
 }


### PR DESCRIPTION
* deps: Smoketest 2.9.0
* deps: Uses Deltics.Memory
* feat: ToBin() overloads for buffers